### PR TITLE
Swap double stab and member tabs

### DIFF
--- a/src/components/layout/BottomNavigation.tsx
+++ b/src/components/layout/BottomNavigation.tsx
@@ -10,18 +10,18 @@ export const BottomNavigation: React.FC = () => {
 
   const tabs = [
     {
-      id: 'practice',
-      label: 'ダブルス',
-      icon: <Zap className="w-6 h-6" />,
-      paths: ['/practice', '/'],
-      href: '/practice',
-    },
-    {
       id: 'members',
       label: 'メンバー',
       icon: <Users className="w-6 h-6" />,
       paths: ['/members'],
       href: '/members',
+    },
+    {
+      id: 'practice',
+      label: 'ダブルス',
+      icon: <Zap className="w-6 h-6" />,
+      paths: ['/practice', '/'],
+      href: '/practice',
     },
     {
       id: 'stats',


### PR DESCRIPTION
ダブルスとメンバータブの順序を入れ替えました。

---
<a href="https://cursor.com/background-agent?bcId=bc-f11d43c4-b748-4c9b-94ec-f6fc2a8f7ceb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f11d43c4-b748-4c9b-94ec-f6fc2a8f7ceb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reorders `BottomNavigation` tabs to place `members` before `practice` (then `stats`).
> 
> - **UI**
>   - Reorders tabs in `src/components/layout/BottomNavigation.tsx`:
>     - Order is now `members` → `practice` → `stats`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94e2b3d1c46887147826645dbd607804cf678569. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->